### PR TITLE
Disable Telemetry and limit providers list

### DIFF
--- a/src/llms/manager.ts
+++ b/src/llms/manager.ts
@@ -12,15 +12,18 @@ export default class LlmManager extends LlmManagerBase {
   }
 
   getStandardEngines = (): string[] => {
-    return [ 'openai', 'anthropic', 'google', 'xai', 'meta', 'ollama', 'mistralai', 'deepseek', 'openrouter', 'groq', 'cerebras' ]
+    // previously used models: ['openai','anthropic','google','xai','meta','ollama','mistralai','deepseek','openrouter','groq','cerebras']
+    return [ 'openai', 'ollama' ]
   }
 
   getPriorityEngines = (): string[] => {
-    return [ 'openai', 'anthropic', 'google', 'ollama' ]
+    // previously used models: ['openai','anthropic','google','ollama']
+    return [ 'openai', 'ollama' ]
   }
 
   getNonChatEngines = (): string[] => {
-    return [ 'huggingface', 'replicate', 'elevenlabs', 'sdwebui', 'falai', 'gladia', 'nvidia', 'fireworks' ]
+    // previously used models: ['huggingface','replicate','elevenlabs','sdwebui','falai','gladia','nvidia','fireworks']
+    return []
   }
 
   isEngineConfigured = (engine: string): boolean => {

--- a/src/main/autoupdate.ts
+++ b/src/main/autoupdate.ts
@@ -18,6 +18,8 @@ export default class AutoUpdater {
   }
 
   private initialize = () => {
+    // telemetry disabled
+    return
 
     // not available on mas
     if (process.mas) {
@@ -105,6 +107,7 @@ export default class AutoUpdater {
   }
 
   check = () => {
+    return
     if (this.downloading) {
       const t = useI18n(this.app)
       dialog.showMessageBox({
@@ -119,6 +122,7 @@ export default class AutoUpdater {
   }
 
   install = () => {
+    return
     if (this.updateAvailable) {
       console.log('Applying update')
       this.hooks.preInstall?.()

--- a/src/plugins/image.ts
+++ b/src/plugins/image.ts
@@ -1,6 +1,7 @@
 
 import { anyDict } from '../types/index'
 import { store } from '../services/store'
+import { getOpenAIApiKey } from '../services/apikey'
 import { i18nInstructions } from '../services/i18n'
 import { PluginParameter } from 'multi-llm-ts'
 import Plugin, { PluginConfig } from './plugin'
@@ -17,7 +18,7 @@ export default class extends Plugin {
 
   isEnabled(): boolean {
     return this.config?.enabled && (
-      (this.config.engine == 'openai' && store.config?.engines.openai.apiKey?.trim().length > 0) ||
+      (this.config.engine == 'openai' && getOpenAIApiKey()?.trim().length > 0) ||
       (this.config.engine == 'google' && store.config?.engines.google.apiKey?.trim().length > 0) ||
       (this.config.engine == 'xai' && store.config?.engines.xai.apiKey?.trim().length > 0) ||
       (this.config.engine == 'replicate' && store.config?.engines.replicate.apiKey?.trim().length > 0) ||

--- a/src/rag/embedder.ts
+++ b/src/rag/embedder.ts
@@ -7,6 +7,7 @@ import similarity from 'compute-cosine-similarity'
 import { Ollama } from 'ollama'
 import OpenAI from 'openai'
 import { GoogleGenerativeAI } from '@google/generative-ai'
+import { getOpenAIApiKey } from '../services/apikey'
 import { Embedding } from 'openai/resources'
 import LlmFactory, { ILlmManager } from '../llms/llm'
 // import path from 'path'
@@ -54,7 +55,7 @@ export default class Embedder {
     if (this.engine === 'openai') {
 
       this.openai = new OpenAI({
-        apiKey: this.config.engines.openai.apiKey,
+        apiKey: getOpenAIApiKey(),
         baseURL: this.config.engines.openai.baseURL || defaults.engines.openai.baseURL,
         dangerouslyAllowBrowser: true
       })
@@ -101,7 +102,7 @@ export default class Embedder {
       const engineConfig = this.config.engines[this.engine] as CustomEngineConfig
       if (engineConfig.api === 'openai') {
         this.openai = new OpenAI({
-          apiKey: engineConfig.apiKey,
+          apiKey: getOpenAIApiKey(),
           baseURL: engineConfig.baseURL,
           dangerouslyAllowBrowser: true
         })

--- a/src/screens/RealtimeChat.vue
+++ b/src/screens/RealtimeChat.vue
@@ -44,6 +44,7 @@
 import { Ref, ref, computed, onMounted } from 'vue'
 import { store } from '../services/store'
 import { t } from '../services/i18n'
+import { getOpenAIApiKey } from '../services/apikey'
 import AnimatedBlob from '../components/AnimatedBlob.vue'
 import NumberFlip from '../components/NumberFlip.vue'
 import useTipsManager from '../composables/tips_manager'
@@ -293,7 +294,7 @@ const startSession = async () => {
 
     peerConnection = await createRealtimeSession(
       audioStream,
-      store.config.engines.openai.apiKey,
+      getOpenAIApiKey(),
       voice.value
     )
 

--- a/src/services/apikey.ts
+++ b/src/services/apikey.ts
@@ -1,0 +1,11 @@
+export function getOpenAIApiKey(): string {
+  try {
+    if (process.env.OPENAI_API_KEY_PATH) {
+      const fs = require('fs');
+      const key = fs.readFileSync(process.env.OPENAI_API_KEY_PATH, 'utf8');
+      if (key) return key.trim();
+    }
+  } catch {}
+  const { store } = require('./store');
+  return store.config.engines.openai.apiKey;
+}

--- a/src/services/image.ts
+++ b/src/services/image.ts
@@ -2,6 +2,7 @@ import { Model, xAIBaseURL } from 'multi-llm-ts'
 import { anyDict, MediaCreationEngine, MediaReference, MediaCreator } from '../types/index'
 import { saveFileContents, download } from '../services/download'
 import { store } from '../services/store'
+import { getOpenAIApiKey } from './apikey'
 import { HfInference } from '@huggingface/inference'
 import { GoogleGenerativeAI } from '@google/generative-ai'
 import Replicate, { FileOutput } from 'replicate'
@@ -13,7 +14,7 @@ export default class ImageCreator implements MediaCreator {
 
   static getEngines(checkApiKey: boolean): MediaCreationEngine[] {
     const engines = []
-    if (!checkApiKey || store.config.engines.openai.apiKey) {
+    if (!checkApiKey || getOpenAIApiKey()) {
       engines.push({ id: 'openai', name: 'OpenAI' })
     }
     if (!checkApiKey || store.config.engines.google.apiKey) {
@@ -96,7 +97,7 @@ export default class ImageCreator implements MediaCreator {
   }
 
   async openai(model: string, parameters: anyDict, reference?: MediaReference): Promise<anyDict> {
-    return this._openai('openai', store.config.engines.openai.apiKey, store.config.engines.openai.baseURL, model, parameters, reference)
+    return this._openai('openai', getOpenAIApiKey(), store.config.engines.openai.baseURL, model, parameters, reference)
   }
 
   async xai(model: string, parameters: anyDict): Promise<anyDict> {

--- a/src/voice/stt-openai.ts
+++ b/src/voice/stt-openai.ts
@@ -2,6 +2,7 @@
 import { Configuration } from 'types/config'
 import { STTEngine, ProgressCallback, TranscribeResponse } from './stt'
 import OpenAI from 'openai'
+import { getOpenAIApiKey } from '../services/apikey'
 
 export default class STTOpenAI implements STTEngine {
 
@@ -17,7 +18,7 @@ export default class STTOpenAI implements STTEngine {
     constructor(config: Configuration) {
     this.config = config
     this.client = new OpenAI({
-      apiKey: config.engines.openai.apiKey,
+      apiKey: getOpenAIApiKey(),
       dangerouslyAllowBrowser: true
     })
   }

--- a/src/voice/tts-openai.ts
+++ b/src/voice/tts-openai.ts
@@ -2,6 +2,7 @@
 import { Configuration } from '../types/config'
 import { SynthesisResponse, TTSEngine } from './tts-engine'
 import OpenAI from 'openai'
+import { getOpenAIApiKey } from '../services/apikey'
 
 export default class TTSOpenAI extends TTSEngine {
 
@@ -29,7 +30,7 @@ export default class TTSOpenAI extends TTSEngine {
   constructor(config: Configuration) {
     super(config)
     this.client = new OpenAI({
-      apiKey: config.engines.openai.apiKey,
+      apiKey: getOpenAIApiKey(),
       dangerouslyAllowBrowser: true
     })
   }


### PR DESCRIPTION
## Summary
- keep provider implementations but limit selectable lists to OpenAI and Ollama
- disable updater by short-circuiting initialization and actions
- load OpenAI keys through `getOpenAIApiKey` helper across plugins and services
- restore full STT/TTS engine selection code

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*
- `npm test` *(fails: vitest not found)*